### PR TITLE
Update the Board API to consistently take a %Game{} or a map with a :board key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Piece.trim/1` to remove starting square from a three element tuple
     containing a piece name, color, and starting square.
 - `Queen`, `Bishop`, `Knight`, and `Rook` modules.
-- `Game.find_piece/2` and `Game.find_pieces/2`.
+- `Board.find_piece/2` and `Board.find_pieces/2`.
 - `Chex.Color` with a `flip/1`.
 - `Piece.King` is now castling aware and provides the castling square(s) in it's
     `available_moves/3`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     public functions under the `Board` module.
 - Board API functions to take a Game struct or map with `:board` key instead of
     the removed board struct.
+- `%Board{}` to be a plain map.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     list of squares.
 - Moved private functions `Game.pickup_piece.2` and `Game.place_piece/3` to
     public functions under the `Board` module.
+- Board API functions to take a Game struct or map with `:board` key instead of
+    the removed board struct.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     implement the Chex.Parser behaviour like `Chex.Parser.FEN.serialize(game)`.
 - OTP application functionality. Users should implement their own state
     management as they see fit for their use case.
+- `Board.new/0`. There's little reason to use a struct for the board
+    representation and no reason to populate it with 64 keys that point to a nil
+    value.

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -18,14 +18,11 @@ defmodule Chex.Board do
     |> reduce(%__MODULE__{}, fn key, map -> Map.put(map, key, nil) end)
   end
 
-  @spec get_piece_name(%Chex.Board{}, Square.t()) :: Piece.name() | nil
-  def get_piece_name(%{} = board, square) do
+  @spec get_piece_name(Game.t(), Square.t()) :: Piece.name() | nil
+  def get_piece_name(%{board: board}, square) do
     case Map.get(board, square) do
-      {name, _color, _sq} ->
-        name
-
-      _ ->
-        nil
+      {name, _color, _sq} -> name
+      _ -> nil
     end
   end
 

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -18,14 +18,9 @@ defmodule Chex.Board do
     |> reduce(%__MODULE__{}, fn key, map -> Map.put(map, key, nil) end)
   end
 
-  @spec get(%Chex.Board{}, Square.t()) :: term | nil
-  def get(%{} = board, square) do
-    board |> Map.get(square)
-  end
-
   @spec get_piece_name(%Chex.Board{}, Square.t()) :: Piece.name() | nil
   def get_piece_name(%{} = board, square) do
-    case get(board, square) do
+    case Map.get(board, square) do
       {name, _color, _sq} ->
         name
 

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -108,9 +108,9 @@ defmodule Chex.Board do
   @doc """
   Get the square of the first matching piece.
   """
-  @spec find_piece(%Chex.Board{}, Piece.t()) :: Square.t() | nil
-  def find_piece(board, piece) do
-    board
+  @spec find_piece(Game.t(), Piece.t()) :: Square.t() | nil
+  def find_piece(game, piece) do
+    game.board
     |> Map.from_struct()
     |> Enum.reduce_while(nil, &finder(piece, &1, &2))
   end

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -101,7 +101,7 @@ defmodule Chex.Board do
     end
   end
 
-  def occupied?(board, square) do
+  def occupied?(%{board: board}, square) do
     !is_nil(Map.get(board, square))
   end
 

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -138,11 +138,11 @@ defmodule Chex.Board do
     end)
   end
 
-  def all_attacking_sqaures(board, color, game) do
-    board
+  def all_attacking_squares(game, color) do
+    game.board
     |> all_occupied_by_color(color)
     |> Enum.map(fn square ->
-      {name, _occupied_color, _sq} = Map.get(board, square)
+      {name, _occupied_color, _sq} = Map.get(game.board, square)
       Chex.Piece.attacking_squares({name, color}, square, game)
     end)
     |> List.flatten()

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -4,8 +4,6 @@ defmodule Chex.Board do
   """
   alias Chex.Square
 
-  defstruct []
-
   @files [:a, :b, :c, :d, :e, :f, :g, :h]
   # @ranks 1..8
 
@@ -76,11 +74,8 @@ defmodule Chex.Board do
 
   def occupied_by_color?(%{board: board}, color, square) do
     case Map.get(board, square) do
-      {_name, ^color, _sq} ->
-        true
-
-      _ ->
-        false
+      {_name, ^color, _sq} -> true
+      _ -> false
     end
   end
 
@@ -94,7 +89,6 @@ defmodule Chex.Board do
   @spec find_piece(Game.t(), Piece.t()) :: Square.t() | nil
   def find_piece(game, piece) do
     game.board
-    |> Map.from_struct()
     |> Enum.reduce_while(nil, &finder(piece, &1, &2))
   end
 
@@ -108,7 +102,6 @@ defmodule Chex.Board do
   @spec find_pieces(Game.t(), Piece.t()) :: [Square.t()] | []
   def find_pieces(%{board: board}, piece) do
     board
-    |> Map.from_struct()
     |> Enum.reduce([], fn {square, {n, c, _}}, acc ->
       if {n, c} == piece, do: [square | acc], else: acc
     end)
@@ -135,7 +128,6 @@ defmodule Chex.Board do
 
   def all_occupied_by_color(%{board: board}, color) do
     board
-    |> Map.from_struct()
     |> Enum.map(fn {k, _v} -> k end)
     |> Enum.filter(&occupied_by_color?(%{board: board}, color, &1))
   end

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -91,7 +91,7 @@ defmodule Chex.Board do
     if index >= 0, do: Enum.at(@files, index)
   end
 
-  def occupied_by_color?(board, color, square) do
+  def occupied_by_color?(%{board: board}, color, square) do
     case Map.get(board, square) do
       {_name, ^color, _sq} ->
         true
@@ -154,6 +154,6 @@ defmodule Chex.Board do
     board
     |> Map.from_struct()
     |> Enum.map(fn {k, _v} -> k end)
-    |> Enum.filter(&occupied_by_color?(board, color, &1))
+    |> Enum.filter(&occupied_by_color?(%{board: board}, color, &1))
   end
 end

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -2,7 +2,6 @@ defmodule Chex.Board do
   @moduledoc """
   Chess board functions.
   """
-  import Map, only: [get_and_update: 3]
   import Enum, only: [reduce: 3]
 
   alias Chex.Square
@@ -17,13 +16,6 @@ defmodule Chex.Board do
       {f, r}
     end
     |> reduce(%__MODULE__{}, fn key, map -> Map.put(map, key, nil) end)
-  end
-
-  def place_at(%__MODULE__{} = board, square, new_piece) do
-    board
-    |> get_and_update(square, fn current_piece ->
-      {current_piece, new_piece}
-    end)
   end
 
   @spec get(%Chex.Board{}, Square.t()) :: term | nil

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -100,10 +100,10 @@ defmodule Chex.Board do
 
   def occupied_by_color?(board, color, square) do
     case Map.get(board, square) do
-      {_name, occupied_color, _sq} ->
-        color == occupied_color
+      {_name, ^color, _sq} ->
+        true
 
-      nil ->
+      _ ->
         false
     end
   end

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -25,13 +25,14 @@ defmodule Chex.Board do
 
   @spec get_piece_name(%Chex.Board{}, Square.t()) :: Piece.name() | nil
   def get_piece_name(%{} = board, square) do
-    board
-    |> get(square)
-    |> extract_piece_name()
-  end
+    case get(board, square) do
+      {name, _color, _sq} ->
+        name
 
-  defp extract_piece_name({name, _c, _id}), do: name
-  defp extract_piece_name(_pice), do: nil
+      _ ->
+        nil
+    end
+  end
 
   @spec pickup_piece(Game.t(), Square.t()) :: {:ok, {Piece.t(), Game.t()}} | {:error, :reason}
   def pickup_piece(game, square) do

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -122,8 +122,8 @@ defmodule Chex.Board do
   @doc """
   Find locations of the specified piece on the board.
   """
-  @spec find_pieces(%Chex.Board{}, Piece.t()) :: [Square.t()] | []
-  def find_pieces(board, piece) do
+  @spec find_pieces(Game.t(), Piece.t()) :: [Square.t()] | []
+  def find_pieces(%{board: board}, piece) do
     board
     |> Map.from_struct()
     |> Enum.reduce([], fn {square, {n, c, _}}, acc ->
@@ -132,7 +132,7 @@ defmodule Chex.Board do
   end
 
   def all_attacking_squares(game, color) do
-    game.board
+    game
     |> all_occupied_by_color(color)
     |> Enum.map(fn square ->
       {name, _occupied_color, _sq} = Map.get(game.board, square)
@@ -143,14 +143,14 @@ defmodule Chex.Board do
   end
 
   def all_possible_squares(game, color) do
-    game.board
+    game
     |> all_occupied_by_color(color)
     |> Enum.map(&Chex.Piece.possible_moves(game, &1))
     |> List.flatten()
     |> Enum.uniq()
   end
 
-  def all_occupied_by_color(board, color) do
+  def all_occupied_by_color(%{board: board}, color) do
     board
     |> Map.from_struct()
     |> Enum.map(fn {k, _v} -> k end)

--- a/lib/chex/board.ex
+++ b/lib/chex/board.ex
@@ -2,21 +2,12 @@ defmodule Chex.Board do
   @moduledoc """
   Chess board functions.
   """
-  import Enum, only: [reduce: 3]
-
   alias Chex.Square
 
   defstruct []
 
   @files [:a, :b, :c, :d, :e, :f, :g, :h]
-  @ranks 1..8
-
-  def new() do
-    for f <- @files, r <- @ranks do
-      {f, r}
-    end
-    |> reduce(%__MODULE__{}, fn key, map -> Map.put(map, key, nil) end)
-  end
+  # @ranks 1..8
 
   @spec get_piece_name(Game.t(), Square.t()) :: Piece.name() | nil
   def get_piece_name(%{board: board}, square) do

--- a/lib/chex/game.ex
+++ b/lib/chex/game.ex
@@ -191,7 +191,7 @@ defmodule Chex.Game do
   # Queenside castle
   defp castle(game, {{:e, r}, {:c, r}}) when r in [1, 8] do
     game =
-      if Board.get_piece_name(game.board, {:c, r}) == :king do
+      if Board.get_piece_name(game, {:c, r}) == :king do
         {:ok, {_piece, _capture, game}} = Board.move(game, {:a, r}, {:d, r})
         game
       else
@@ -204,7 +204,7 @@ defmodule Chex.Game do
   # Kingside castle
   defp castle(game, {{:e, r}, {:g, r}}) when r in [1, 8] do
     game =
-      if Board.get_piece_name(game.board, {:g, r}) == :king do
+      if Board.get_piece_name(game, {:g, r}) == :king do
         {:ok, {piece, game}} = Board.pickup_piece(game, {:h, r})
         {:ok, {_cap, game}} = Board.place_piece(game, {:f, r}, piece)
         game

--- a/lib/chex/game.ex
+++ b/lib/chex/game.ex
@@ -4,7 +4,7 @@ defmodule Chex.Game do
   """
   alias Chex.{Board, Color, Game, Piece, Square}
 
-  defstruct board: Board.new(),
+  defstruct board: %{},
             active_color: :white,
             castling: [:K, :Q, :k, :q],
             en_passant: nil,

--- a/lib/chex/game/checking.ex
+++ b/lib/chex/game/checking.ex
@@ -9,7 +9,7 @@ defmodule Chex.Game.Checking do
   def in_check?(game, color) do
     square = Board.find_piece(game.board, {:king, color})
 
-    Board.all_attacking_sqaures(game.board, Color.flip(color), game)
+    Board.all_attacking_squares(game, Color.flip(color))
     |> Enum.member?(square)
   end
 

--- a/lib/chex/game/checking.ex
+++ b/lib/chex/game/checking.ex
@@ -7,7 +7,7 @@ defmodule Chex.Game.Checking do
 
   @spec in_check?(Game.t(), Color.t()) :: bool()
   def in_check?(game, color) do
-    square = Board.find_piece(game.board, {:king, color})
+    square = Board.find_piece(game, {:king, color})
 
     Board.all_attacking_squares(game, Color.flip(color))
     |> Enum.member?(square)

--- a/lib/chex/parser/fen.ex
+++ b/lib/chex/parser/fen.ex
@@ -43,7 +43,7 @@ defmodule Chex.Parser.FEN do
 
   def extension(), do: nil
 
-  @spec decode_board(String.t()) :: %Board{}
+  @spec decode_board(String.t()) :: %{}
   def decode_board(str) do
     str
     |> split("/")
@@ -54,12 +54,12 @@ defmodule Chex.Parser.FEN do
       |> decode_rank([], 0, 8 - i)
     end)
     |> List.flatten()
-    |> Enum.reduce(%Board{}, fn {square, piece}, board ->
+    |> Enum.reduce(%{}, fn {square, piece}, board ->
       Map.put(board, square, Tuple.append(piece, square))
     end)
   end
 
-  @spec serialize_board(%Board{}) :: String.t()
+  @spec serialize_board(%{}) :: String.t()
   def serialize_board(board) do
     for r <- 8..1, f <- Board.files() do
       Map.get(board, {f, r})

--- a/lib/chex/piece.ex
+++ b/lib/chex/piece.ex
@@ -27,7 +27,7 @@ defmodule Chex.Piece do
     {name, color, _id} = Map.get(game.board, square)
 
     to_module(name).possible_moves(color, square, game)
-    |> Enum.reject(&Board.occupied_by_color?(game.board, color, &1))
+    |> Enum.reject(&Board.occupied_by_color?(game, color, &1))
     |> Enum.reject(fn sq ->
       {:ok, {_piece, _capture, psudo_game}} = Board.move(game, square, sq)
       Game.in_check?(psudo_game, color)

--- a/lib/chex/piece/king.ex
+++ b/lib/chex/piece/king.ex
@@ -66,7 +66,7 @@ defmodule Chex.Piece.King do
     squares = kingside_squares(color)
     attacked_squares = Board.all_attacking_squares(game, Color.flip(color))
 
-    occupied = Enum.any?(squares, &Board.occupied?(game.board, &1))
+    occupied = Enum.any?(squares, &Board.occupied?(game, &1))
     attacked = Enum.any?(squares, fn sq -> sq in attacked_squares end)
     has_right = piece_to_right(:king, color) in game.castling
 
@@ -78,7 +78,7 @@ defmodule Chex.Piece.King do
 
     occupied =
       queenside_squares(color)
-      |> Enum.any?(&Board.occupied?(game.board, &1))
+      |> Enum.any?(&Board.occupied?(game, &1))
 
     attacked =
       queenside_squares(color, :attacking)

--- a/lib/chex/piece/king.ex
+++ b/lib/chex/piece/king.ex
@@ -10,7 +10,7 @@ defmodule Chex.Piece.King do
       possible_squares(square)
       |> maybe_prepend_castling(game, color)
 
-    moves -- Board.all_attacking_sqaures(game.board, Color.flip(color), game)
+    moves -- Board.all_attacking_squares(game, Color.flip(color))
   end
 
   def attacking_squares(_color, square, _game), do: possible_squares(square)
@@ -64,7 +64,7 @@ defmodule Chex.Piece.King do
 
   defp can_kingside_castle(game, color) do
     squares = kingside_squares(color)
-    attacked_squares = Board.all_attacking_sqaures(game.board, Color.flip(color), game)
+    attacked_squares = Board.all_attacking_squares(game, Color.flip(color))
 
     occupied = Enum.any?(squares, &Board.occupied?(game.board, &1))
     attacked = Enum.any?(squares, fn sq -> sq in attacked_squares end)
@@ -74,7 +74,7 @@ defmodule Chex.Piece.King do
   end
 
   defp can_queenside_castle(game, color) do
-    attacked_squares = Board.all_attacking_sqaures(game.board, Color.flip(color), game)
+    attacked_squares = Board.all_attacking_squares(game, Color.flip(color))
 
     occupied =
       queenside_squares(color)

--- a/lib/chex/piece/knight.ex
+++ b/lib/chex/piece/knight.ex
@@ -23,7 +23,7 @@ defmodule Chex.Piece.Knight do
       {Board.file_offset(file, f_dir), rank + r_dir}
     end)
     |> Enum.filter(&Square.valid?(&1))
-    |> Enum.reject(&Board.occupied_by_color?(game.board, color, &1))
+    |> Enum.reject(&Board.occupied_by_color?(game, color, &1))
   end
 
   @impl true

--- a/lib/chex/piece/movement.ex
+++ b/lib/chex/piece/movement.ex
@@ -37,7 +37,7 @@ defmodule Chex.Piece.Movement do
   defp prepare_arguments(_game, squares, _color, nil, _limit), do: {squares, 0}
 
   defp prepare_arguments(game, squares, color, new_sq, limit) do
-    occupied_by_enemy = !Board.occupied_by_color?(game.board, color, new_sq)
+    occupied_by_enemy = !Board.occupied_by_color?(game, color, new_sq)
     squares = maybe_add_square(squares, new_sq, occupied_by_enemy)
     occupied = Board.occupied?(game, new_sq)
     limit = occupied_limit(limit, occupied)

--- a/lib/chex/piece/movement.ex
+++ b/lib/chex/piece/movement.ex
@@ -39,7 +39,7 @@ defmodule Chex.Piece.Movement do
   defp prepare_arguments(game, squares, color, new_sq, limit) do
     occupied_by_enemy = !Board.occupied_by_color?(game.board, color, new_sq)
     squares = maybe_add_square(squares, new_sq, occupied_by_enemy)
-    occupied = Board.occupied?(game.board, new_sq)
+    occupied = Board.occupied?(game, new_sq)
     limit = occupied_limit(limit, occupied)
 
     {squares, limit}

--- a/lib/chex/piece/pawn.ex
+++ b/lib/chex/piece/pawn.ex
@@ -16,7 +16,7 @@ defmodule Chex.Piece.Pawn do
 
     attacks =
       attacking_squares(color, square, game)
-      |> Enum.filter(&occupied?(game.board, &1))
+      |> Enum.filter(&occupied?(game, &1))
       |> Enum.reject(&occupied_by_color?(game.board, color, &1))
 
     moves ++ attacks

--- a/lib/chex/piece/pawn.ex
+++ b/lib/chex/piece/pawn.ex
@@ -12,12 +12,12 @@ defmodule Chex.Piece.Pawn do
   def possible_moves(color, square, game) do
     moves =
       moves(color, square)
-      |> Enum.reject(&occupied_by_color?(game.board, flip(color), &1))
+      |> Enum.reject(&occupied_by_color?(game, flip(color), &1))
 
     attacks =
       attacking_squares(color, square, game)
       |> Enum.filter(&occupied?(game, &1))
-      |> Enum.reject(&occupied_by_color?(game.board, color, &1))
+      |> Enum.reject(&occupied_by_color?(game, color, &1))
 
     moves ++ attacks
   end

--- a/test/chex/board_test.exs
+++ b/test/chex/board_test.exs
@@ -19,9 +19,11 @@ defmodule Chex.BoardTest do
   test "occupied_by_color" do
     results =
       for color <- [:white, :black], piece_color <- [:white, :black] do
-        Chex.Board.new()
-        |> Map.put({:a, 1}, {:pawn, piece_color, {:a, 1}})
-        |> Chex.Board.occupied_by_color?(color, {:a, 1})
+        board =
+          Chex.Board.new()
+          |> Map.put({:a, 1}, {:pawn, piece_color, {:a, 1}})
+
+        Chex.Board.occupied_by_color?(%{board: board}, color, {:a, 1})
       end
 
     assert_value(results == [true, false, false, true])

--- a/test/chex/board_test.exs
+++ b/test/chex/board_test.exs
@@ -30,12 +30,12 @@ defmodule Chex.BoardTest do
   describe "Board.find_piece/2" do
     test "returns the square of the first matching piece" do
       {:ok, game} = Game.new()
-      assert {:a, 2} == Board.find_piece(game.board, {:pawn, :white})
+      assert {:a, 2} == Board.find_piece(game, {:pawn, :white})
     end
 
     test "returns nil when the piece is not on the board" do
       {:ok, game} = Game.new(@empty_board)
-      assert nil == Board.find_piece(game.board, {:pawn, :white})
+      assert nil == Board.find_piece(game, {:pawn, :white})
     end
   end
 
@@ -44,12 +44,12 @@ defmodule Chex.BoardTest do
       {:ok, game} = Game.new()
 
       assert [h: 2, g: 2, f: 2, e: 2, d: 2, c: 2, b: 2, a: 2] ==
-               Board.find_pieces(game.board, {:pawn, :white})
+               Board.find_pieces(game, {:pawn, :white})
     end
 
     test "returns an empty list when the piece is not on the board" do
       {:ok, game} = Game.new(@empty_board)
-      assert [] == Board.find_pieces(game.board, {:pawn, :white})
+      assert [] == Board.find_pieces(game, {:pawn, :white})
     end
   end
 end

--- a/test/chex/board_test.exs
+++ b/test/chex/board_test.exs
@@ -19,9 +19,9 @@ defmodule Chex.BoardTest do
   test "occupied_by_color" do
     results =
       for color <- [:white, :black], piece_color <- [:white, :black] do
-        board =
-          Chex.Board.new()
-          |> Map.put({:a, 1}, {:pawn, piece_color, {:a, 1}})
+        board = %{
+          {:a, 1} => {:pawn, piece_color, {:a, 1}}
+        }
 
         Chex.Board.occupied_by_color?(%{board: board}, color, {:a, 1})
       end

--- a/test/chex/game_test.exs
+++ b/test/chex/game_test.exs
@@ -12,7 +12,6 @@ defmodule Chex.GameTest do
         game == %Game{
           active_color: :white,
           board: %{
-            :__struct__ => Chex.Board,
             {:a, 1} => {:rook, :white, {:a, 1}},
             {:a, 2} => {:pawn, :white, {:a, 2}},
             {:a, 7} => {:pawn, :black, {:a, 7}},
@@ -250,7 +249,6 @@ defmodule Chex.GameTest do
                 %Chex.Game{
                   active_color: :black,
                   board: %{
-                    :__struct__ => Chex.Board,
                     {:a, 1} => {:rook, :white, {:a, 1}},
                     {:a, 8} => {:rook, :black, {:a, 8}},
                     {:e, 1} => nil,
@@ -278,7 +276,6 @@ defmodule Chex.GameTest do
                 %Chex.Game{
                   active_color: :white,
                   board: %{
-                    :__struct__ => Chex.Board,
                     {:a, 1} => {:rook, :white, {:a, 1}},
                     {:a, 8} => {:rook, :black, {:a, 8}},
                     {:e, 1} => {:king, :white, {:e, 1}},
@@ -306,7 +303,6 @@ defmodule Chex.GameTest do
                 %Chex.Game{
                   active_color: :black,
                   board: %{
-                    :__struct__ => Chex.Board,
                     {:a, 1} => nil,
                     {:a, 8} => {:rook, :black, {:a, 8}},
                     {:c, 1} => {:king, :white, {:e, 1}},
@@ -334,7 +330,6 @@ defmodule Chex.GameTest do
                 %Chex.Game{
                   active_color: :white,
                   board: %{
-                    :__struct__ => Chex.Board,
                     {:a, 1} => {:rook, :white, {:a, 1}},
                     {:a, 8} => nil,
                     {:c, 8} => {:king, :black, {:e, 8}},

--- a/test/chex/parser/fen_test.exs
+++ b/test/chex/parser/fen_test.exs
@@ -15,7 +15,6 @@ defmodule Chex.Parser.FENTest do
     {:ok, game} = Chex.Parser.FEN.parse(@starting_pos)
 
     assert game.board == %{
-             :__struct__ => Chex.Board,
              {:c, 2} => {:pawn, :white, {:c, 2}},
              {:g, 1} => {:knight, :white, {:g, 1}},
              {:a, 8} => {:rook, :black, {:a, 8}},
@@ -55,7 +54,6 @@ defmodule Chex.Parser.FENTest do
     {:ok, game} = Chex.Parser.FEN.parse(@after_nf3)
 
     assert game.board == %{
-             :__struct__ => Chex.Board,
              {:c, 2} => {:pawn, :white, {:c, 2}},
              {:f, 1} => {:bishop, :white, {:f, 1}},
              {:c, 5} => {:pawn, :black, {:c, 5}},
@@ -159,7 +157,6 @@ defmodule Chex.Parser.FENTest do
 
   test "serializes complicated board" do
     board = %{
-      :__struct__ => Chex.Board,
       {:a, 3} => {:pawn, :white, {:a, 3}},
       {:a, 5} => {:pawn, :black, {:a, 5}},
       {:a, 8} => {:rook, :black, {:a, 8}},


### PR DESCRIPTION
## Description
This contains a number of fixes and changes include typo fixes, refactored Board API, and the removal of the Board struct.

## Related Issue
#17 

## Motivation and Context
`%Board{}` was acting as a plain map and the destruct was empty.  but doesn't implement the Enumerable protocol, thus requiring calls to /from_struct. 

## How Has This Been Tested?
`mix test` and `mix test --cover`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
