### PR TITLE
Add Stalemate detection and :draw result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `available_moves/3`.
 - `Board.get_piece_name/2` to get just the name of a piece at a square.
 - Castling support.
+- Checkmate support.
+- Stalemate support.
 
 ### Changed
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,3 +4,8 @@ use Mix.Config
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
+
+if Mix.env() == :dev do
+  config :mix_test_watch,
+    clear: true
+end

--- a/lib/chex/game.ex
+++ b/lib/chex/game.ex
@@ -82,8 +82,9 @@ defmodule Chex.Game do
     end
   end
 
-  defdelegate in_check?(board, color), to: Game.Checking
-  defdelegate checkmate?(board), to: Game.Checking
+  defdelegate in_check?(game, color), to: Game.Checking
+  defdelegate checkmate?(game), to: Game.Checking
+  defdelegate stalemate?(game), to: Game.Checking
 
   @spec result(Game.t()) :: Color.t() | :draw | nil
   def result(game), do: game.result
@@ -261,15 +262,17 @@ defmodule Chex.Game do
 
   defp maybe_promote_pawn(game, _new_piece), do: game
 
-  defp maybe_update_result(%{check: color} = game) when not is_nil(color) do
-    case checkmate?(game) do
-      true ->
-        %{game | result: Color.flip(color)}
-
-      _ ->
-        game
+  defp maybe_update_result(%{check: nil} = game) do
+    case stalemate?(game) do
+      true -> %{game | result: :draw}
+      _ -> game
     end
   end
 
-  defp maybe_update_result(game), do: game
+  defp maybe_update_result(%{check: color} = game) do
+    case checkmate?(game) do
+      true -> %{game | result: Color.flip(color)}
+      _ -> game
+    end
+  end
 end

--- a/lib/chex/game/checking.ex
+++ b/lib/chex/game/checking.ex
@@ -17,4 +17,11 @@ defmodule Chex.Game.Checking do
   def checkmate?(%{active_color: color} = game) do
     in_check?(game, color) && Board.all_possible_squares(game, color) == []
   end
+
+  @spec stalemate?(Game.t()) :: bool()
+  def stalemate?(%{check: check}) when not is_nil(check), do: false
+
+  def stalemate?(%{active_color: color} = game) do
+    Board.all_possible_squares(game, color) == []
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,8 @@ defmodule Chex.MixProject do
       {:assert_value, "~> 0.9.3", only: [:dev, :test]},
       {:credo, "~> 1.5.0-rc.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: [:dev], runtime: false},
-      {:ex_doc, "~> 0.21", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.21", only: :dev, runtime: false},
+      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -11,5 +11,6 @@
   "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
   "makeup": {:hex, :makeup, "1.0.3", "e339e2f766d12e7260e6672dd4047405963c5ec99661abdc432e6ec67d29ef95", [:mix], [{:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "2e9b4996d11832947731f7608fed7ad2f9443011b3b479ae288011265cdd3dad"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.1", "4f0e96847c63c17841d42c08107405a005a2680eb9c7ccadfd757bd31dabccfb", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "f2438b1a80eaec9ede832b5c41cd4f373b38fd7aa33e3b22d9db79e640cbde11"},
+  "mix_test_watch": {:hex, :mix_test_watch, "1.0.2", "34900184cbbbc6b6ed616ed3a8ea9b791f9fd2088419352a6d3200525637f785", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "47ac558d8b06f684773972c6d04fcc15590abdb97aeb7666da19fcbfdc441a07"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
 }

--- a/test/chex/stalemate_test.exs
+++ b/test/chex/stalemate_test.exs
@@ -1,0 +1,49 @@
+defmodule Chex.StalemateTest do
+  use ExUnit.Case, async: true
+
+  alias Chex.Game
+
+  describe "only king remains" do
+    test "king and pawm stalemate" do
+      {:ok, game} = Game.new("4k3/4P3/8/4K3/8/8/8/8 w - - 0 1")
+      {:ok, game} = Game.move(game, "e5e6")
+
+      assert Game.result(game) == :draw
+    end
+
+    test "king and rook stalemate" do
+      {:ok, game} = Game.new("8/1R6/8/8/8/2K5/8/k7 w - - 0 1")
+      {:ok, game} = Game.move(game, "b7b2")
+
+      assert Game.result(game) == :draw
+    end
+
+    test "wrong bishop stalemate" do
+      {:ok, game} = Game.new("1k6/P7/K7/6B1/8/8/8/8 w - - 0 1")
+      {:ok, game} = Game.move(game, "g5f4")
+      assert Game.in_check?(game, :black) == true
+
+      {:ok, game} = Game.move(game, "b8a8")
+      assert Game.result(game) == nil
+
+      {:ok, game} = Game.move(game, "f4e5")
+      assert Game.result(game) == :draw
+    end
+  end
+
+  describe "more than king remains" do
+    test "pinned bishop stalemate" do
+      {:ok, game} = Game.new("kb6/8/1K6/8/8/8/8/7R w - - 0 1")
+      {:ok, game} = Game.move(game, "h1h8")
+
+      assert Game.result(game) == :draw
+    end
+
+    test "queen vs pawn endgame" do
+      {:ok, game} = Game.new("8/8/8/6K1/8/1Q6/p7/k7 w - - 0 1")
+      {:ok, game} = Game.move(game, "g5f5")
+
+      assert Game.result(game) == :draw
+    end
+  end
+end


### PR DESCRIPTION
## Description
Adds a `Game.Checking.stalemate?/1` and adds `:draw` to the possible values for `Game.result/1`.

## Related Issue
Will close #29.

## Motivation and Context
Chex currently doesn't have stalemate support. Games that end in stalemate still return `nil` as the result.

## How Has This Been Tested?
Added `Chex.StalemateTest`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
