### PR TITLE
Implement Inspect protocol for Chex.Game

### DIFF
--- a/lib/chex/game/inspect.ex
+++ b/lib/chex/game/inspect.ex
@@ -1,0 +1,52 @@
+defimpl Inspect, for: Chex.Game do
+  @unicode_map %{
+    {:white, :pawn} => "♙",
+    {:white, :rook} => "♖",
+    {:white, :knight} => "♘",
+    {:white, :bishop} => "♗",
+    {:white, :queen} => "♕",
+    {:white, :king} => "♔",
+    {:black, :pawn} => "♟",
+    {:black, :rook} => "♜",
+    {:black, :knight} => "♞",
+    {:black, :bishop} => "♝",
+    {:black, :queen} => "♛",
+    {:black, :king} => "♚",
+    nil => " "
+  }
+
+  @ranks 8..1
+  @files [:a, :b, :c, :d, :e, :f, :g, :h]
+
+  @doc """
+  Output a string in the unicode notation shown below.
+
+  iex> Chex.Game.new
+    8 [♜][♞][♝][♛][♚][♝][♞][♜]
+    7 [♟][♟][♟][♟][♟][♟][♟][♟]
+    6 [ ][ ][ ][ ][ ][ ][ ][ ]
+    5 [ ][ ][ ][ ][ ][ ][ ][ ]
+    4 [ ][ ][ ][ ][ ][ ][ ][ ]
+    3 [ ][ ][ ][ ][ ][ ][ ][ ]
+    2 [♙][♙][♙][♙][♙][♙][♙][♙]
+    1 [♖][♘][♗][♕][♔][♗][♘][♖]
+       a  b  c  d  e  f  g  h
+  """
+  def inspect(game, opts) do
+    for rank <- @ranks, file <- @files do
+      piece =
+        case Map.get(game.board, {file, rank}) do
+          {material, color, _} -> {color, material}
+          _ -> nil
+        end
+
+      unicode = Map.get(@unicode_map, piece)
+      "[#{unicode}]"
+    end
+    |> Enum.chunk_every(8)
+    |> Enum.with_index()
+    |> Enum.map(fn {row, rank} -> ["#{8 - rank} " | row] |> Enum.join("") end)
+    |> Enum.concat(["   a  b  c  d  e  f  g  h"])
+    |> Enum.join("\n")
+  end
+end

--- a/test/chex/game/inspect_test.exs
+++ b/test/chex/game/inspect_test.exs
@@ -1,0 +1,45 @@
+defmodule Chex.Game.InspectTest do
+  use ExUnit.Case, async: true
+
+  describe "inspect game" do
+    test "new game" do
+      expected =
+        """
+        8 [♜][♞][♝][♛][♚][♝][♞][♜]
+        7 [♟][♟][♟][♟][♟][♟][♟][♟]
+        6 [ ][ ][ ][ ][ ][ ][ ][ ]
+        5 [ ][ ][ ][ ][ ][ ][ ][ ]
+        4 [ ][ ][ ][ ][ ][ ][ ][ ]
+        3 [ ][ ][ ][ ][ ][ ][ ][ ]
+        2 [♙][♙][♙][♙][♙][♙][♙][♙]
+        1 [♖][♘][♗][♕][♔][♗][♘][♖]
+           a  b  c  d  e  f  g  h
+        """
+        |> String.trim()
+
+      assert expected == inspect(Chex.new_game!())
+    end
+
+    test "promotion game" do
+      expected =
+        """
+        8 [ ][ ][ ][ ][ ][ ][ ][ ]
+        7 [ ][ ][♚][ ][♙][ ][ ][ ]
+        6 [ ][ ][ ][ ][ ][ ][ ][ ]
+        5 [ ][ ][ ][ ][ ][ ][ ][ ]
+        4 [ ][ ][ ][ ][ ][ ][ ][ ]
+        3 [ ][ ][ ][ ][ ][ ][ ][ ]
+        2 [ ][ ][♔][ ][ ][ ][ ][ ]
+        1 [ ][ ][ ][ ][ ][ ][ ][ ]
+           a  b  c  d  e  f  g  h
+        """
+        |> String.trim()
+
+      {:ok, game} = Chex.Game.new("8/2k1P3/8/8/8/8/2K5/8 w - - 0 1")
+
+      IO.inspect(game)
+
+      assert expected == inspect(game)
+    end
+  end
+end

--- a/test/chex/game_test.exs
+++ b/test/chex/game_test.exs
@@ -1,6 +1,5 @@
 defmodule Chex.GameTest do
   use ExUnit.Case, async: true
-  import AssertValue
 
   alias Chex.Game
 
@@ -8,7 +7,7 @@ defmodule Chex.GameTest do
     test "returns new game state" do
       {:ok, game} = Game.new()
 
-      assert_value(
+      assert(
         game == %Game{
           active_color: :white,
           board: %{


### PR DESCRIPTION
Inspect protocol implemented for Chex.Game struct.

## Description
Returns unicode representation of chess board.

## Related Issue
https://github.com/alecho/chex/issues/60

## Motivation and Context
Provides a human readable representation of the game state.

## How Has This Been Tested?
Tested using default state, and state generated from FEN string.

## Screenshots (if appropriate):
<img width="242" alt="Screen Shot 2021-10-13 at 3 57 08 PM" src="https://user-images.githubusercontent.com/1435196/137211490-039c55cd-1d8b-4953-8d3f-a4f67e495a74.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
